### PR TITLE
fix: Use key props to prevent rendering issues

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -69,14 +69,14 @@ export default function Home() {
         <tbody>
           {filteredAdvocates.map((advocate) => {
             return (
-              <tr>
+              <tr key={advocate.id}>
                 <td>{advocate.firstName}</td>
                 <td>{advocate.lastName}</td>
                 <td>{advocate.city}</td>
                 <td>{advocate.degree}</td>
                 <td>
                   {advocate.specialties.map((s) => (
-                    <div>{s}</div>
+                    <div key={s}>{s}</div>
                   ))}
                 </td>
                 <td>{advocate.yearsOfExperience}</td>


### PR DESCRIPTION
This change adds key props to the list of advocates and their specialties.

Adding unique key props helps React correctly track changes, improving rendering performance and preventing issues like incorrect DOM updates or duplicated elements.

Additionally this resolves a warning in the console about missing key props:
`Warning: Each child in a list should have a unique "key" prop.`